### PR TITLE
Rollup of recent changes for app service code.

### DIFF
--- a/lib/Bio/KBase/AppService/AppScript.pm
+++ b/lib/Bio/KBase/AppService/AppScript.pm
@@ -246,6 +246,8 @@ sub run
 	local @ARGV = @$args;
 	($opt, my $usage) = describe_options("%c %o app-service-url app-definition.json param-values.json",
 					     ["user-error-file=s", "File to which user-readable errors are written"],
+					     ["override-output-file=s", "Override output file that was passed in params"],
+					     ["override-output-path=s", "Override output path that was passed in params"],
 					     ["preflight=s", "Run the app in preflight mode. Write a JSON object to the file specified representing the expected runtime, requested CPU count, and memory use for this application invocation."],
 					     
 					     ["help|h", "Show this help message."]);
@@ -284,7 +286,7 @@ sub run
     $error_fh->autoflush(1);
 
     eval {
-	$self->preprocess_parameters($app_def_file, $params_file);
+	$self->preprocess_parameters($app_def_file, $params_file, $opt);
     };
     if ($@)
     {
@@ -622,12 +624,15 @@ sub stage_in
 
 sub preprocess_parameters
 {
-    my($self, $app_def_file, $params_file) = @_;
+    my($self, $app_def_file, $params_file, $opt) = @_;
     
     my $json = JSON::XS->new->pretty(1)->relaxed(1);
 
     my $app_def = $json->decode(scalar read_file($app_def_file));
     my $params =  $json->decode(scalar read_file($params_file));
+
+    $params->{output_path} = $opt->override_output_path if $opt->override_output_path;
+    $params->{output_file} = $opt->override_output_file if $opt->override_output_file;
 
     #
     # UTF8 decode the output path to try to fix up the international characters.

--- a/lib/Bio/KBase/AppService/slurm_batch.tt
+++ b/lib/Bio/KBase/AppService/slurm_batch.tt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #SBATCH --account [% sbatch_account %]
 #SBATCH --job-name [% sbatch_job_name %]
 #SBATCH --mem [% sbatch_job_mem %]

--- a/service-scripts/p3x-qstat.pl
+++ b/service-scripts/p3x-qstat.pl
@@ -34,6 +34,7 @@ my($opt, $usage) = describe_options("%c %o [jobid...]",
 				    ["end-time=s" => "Limit results to jobs submitted before this time"],
 				    ["genome-id" => "For genome annotation jobs, look up the genome ID if possible"],
 				    ["ids-from=s" => "Use the given file to read IDs from"],
+				    ["ids-only" => "Only show ids of matching jobs"],
 				    ["user-metadata=s" => "Limit to jobs with the given user metadata"],
 				    ["show-output-file" => "Show the output filename"],
 				    ["show-output-path" => "Show the output path"],
@@ -235,6 +236,13 @@ if ($opt->count)
     exit 0;
 }
 
+if ($opt->ids_only)
+{
+    my $qry = qq(SELECT t.id $full_condition);
+    my $res = $dbh->selectcol_arrayref($qry, undef, @params);
+    print "@$res\n";
+    exit 0;
+}    
 
 my $qry = qq(SELECT t.id as task_id, t.state_code, t.owner, t.application_id,  
 	     if(submit_time = default(submit_time), "", submit_time) as submit_time,

--- a/service-scripts/p3x-resubmit-load-files.pl
+++ b/service-scripts/p3x-resubmit-load-files.pl
@@ -1,0 +1,111 @@
+
+#
+# Resubmit a job's load files for indexing.
+#
+
+use strict;
+use P3AuthToken;
+use File::Temp;
+use File::Basename;
+use Bio::KBase::AppService::SchedulerDB;
+use Bio::P3::Workspace::WorkspaceClientExt;
+use Bio::KBase::AppService::AppConfig qw(data_api_url);
+use Getopt::Long::Descriptive;
+use Data::Dumper;
+use JSON::XS;
+use IPC::Run;
+
+my($opt, $usage) = describe_options("%c %o jobid...",
+				    ["help|h" => "Show this help message"]);
+
+print($usage->text), exit 0 if $opt->help;
+print($usage->text), exit 1 if @ARGV == 0;
+
+my @jobs = @ARGV;
+
+my $db = Bio::KBase::AppService::SchedulerDB->new;
+my $ws = Bio::P3::Workspace::WorkspaceClientExt->new;
+my $token = P3AuthToken->new;
+
+my @conds;
+my @params;
+
+for my $id (@jobs)
+{
+    if ($id !~ /^\d+$/)
+    {
+	die "Invalid job id $id\n";
+    }
+}
+my $vals = join(", ", @jobs);
+
+push(@conds, "id IN ($vals)");
+
+my $cond = join(" AND ", map { "($_)" } @conds);
+
+my $qry = qq(SELECT id, output_path, output_file, application_id
+	     FROM Task
+	     WHERE $cond);
+
+
+my $res = $db->dbh->selectall_arrayref($qry, undef, @params);
+
+for my $ent (@$res)
+{
+    my($job_id, $output_path, $output_file, $app_id) = @$ent;
+
+    if ($app_id eq 'ComprehensiveGenomeAnalysis')
+    {
+	$output_path .= "/.$output_file";
+	$output_file = "annotation";
+    }
+
+    resubmit_load_files($job_id, $output_path, $output_file, $app_id);
+}
+
+sub resubmit_load_files
+{
+    my($job_id, $output_path, $output_file, $app_id) = @_;
+
+    my $temp = File::Temp->newdir(CLEANUP => 1);
+    my $genome_url = data_api_url . "/indexer/genome";
+
+    my $path = "$output_path/.$output_file/load_files";
+    print "$path\n";
+    my $res = $ws->ls({ paths => [$path], adminmode => 1 });
+    my @opts;
+    push(@opts, "-H", "Authorization: " . $token->token);
+    push(@opts, "-H", "Content-Type: multipart/form-data");
+    
+    for my $ent (@{$res->{$path}})
+    {
+	my($file, $type, $path) = @$ent;
+	next unless $type eq 'json';
+	my $dest = "$temp/$file";
+
+	my $key = basename($file, ".json");
+
+	my $x = $ws->download_file("$path$file", $dest, 1, $token->token, { admin => 1 });
+
+	push(@opts, "-F", "$key=\@$dest");
+    }
+    push(@opts, $genome_url);
+    die Dumper(@opts);
+
+#curl -H "Authorization: AUTHORIZATION_TOKEN_HERE" -H "Content-Type: multipart/form-data" -F "genome=@genome.json" -F "genome_feature=@genome_feature_patric.json" -F "genome_feature=@genome_feature_refseq.json" -F "genome_feature=@genome_feature_brc1.json" -F "genome_sequence=@genome_sequence.json" -F "pathway=@pathway.json" -F "sp_gene=@sp_gene.json"  
+
+    my($stdout, $stderr);
+    
+    my $ok = IPC::Run::run(["curl", @opts], '>', \$stdout);
+    if (!$ok)
+    {
+	warn "Error $? invoking curl @opts\n";
+    }
+
+    my $json = JSON::XS->new->allow_nonref;
+    my $data = $json->decode($stdout);
+
+    my $queue_id = $data->{id};
+
+    print "Submitted indexing job $queue_id\n";
+}


### PR DESCRIPTION
Add --override flags to app scripts for output file and output path (for debugging)
Add id list output to p3x-qstat
Add support to select a slurm partition via an app's preflight (used currently in Taxonomic Classification to select a partition with the data kept hot in memory)