### PR TITLE
NFS bindings update

### DIFF
--- a/lib/Bio/KBase/AppService/slurm_batch.tt
+++ b/lib/Bio/KBase/AppService/slurm_batch.tt
@@ -155,11 +155,15 @@ export TEMPDIR=/tmp
 #
 # Check for metagenome & blast databases and bind into the container run
 #
-blast_bind=""
+nfs_bindings=""
 mg_bind=""
-if [[ -d /vol/blastdb/bvbrc-service ]] ; then
-    blast_bind=",/vol/blastdb/bvbrc-service"
-fi
+
+NFS_bindings="/vol/bvbrc/production/application-backend/bvbrc_ceirr_data_submission /vol/blastdb/bvbrc-service"
+for dir in $NFS_bindings ; do
+    if [[ -d $dir ]] ; then
+	nfs_bindings="$nfs_bindings,$dir"
+    fi
+done
 
 #
 # We need to bind both /vol/patric3/metagenome_dbs and /disks-patric-data/metagenome_dbs
@@ -228,7 +232,7 @@ fi
 singularity run \
 	    -H $WORKDIR \
 	    --env P3_WORKDIR="$WORKDIR",P3_DATA_CONTAINER="$P3_DATA_CONTAINER",P3_DATA_BIND_DESTINATION="$P3_DATA_BIND_DESTINATION" \
-	    -B $WORKDIR:/tmp${data_bind}${blast_bind}${mg_bind}${bigtmp_bind} \
+	    -B $WORKDIR:/tmp${data_bind}${nfs_bindings}${mg_bind}${bigtmp_bind} \
 	    --pwd /tmp \
 	    [% container_image %] \
 	    p3x-app-shepherd --app-service [% task.appserv_url %] --task-id [% task.id %] [% task.script %] [% task.monitor_url %] app_spec params &

--- a/lib/Bio/KBase/AppService/slurm_batch.tt
+++ b/lib/Bio/KBase/AppService/slurm_batch.tt
@@ -158,7 +158,7 @@ export TEMPDIR=/tmp
 nfs_bindings=""
 mg_bind=""
 
-NFS_bindings="/vol/bvbrc/production/application-backend/bvbrc_ceirr_data_submission /vol/blastdb/bvbrc-service"
+NFS_bindings="/vol/bvbrc/production/application-backend/bvbrc_ceirr_data_submission /vol/blastdb/bvbrc-service /vol/patric3/tmp"
 for dir in $NFS_bindings ; do
     if [[ -d $dir ]] ; then
 	nfs_bindings="$nfs_bindings,$dir"
@@ -220,19 +220,10 @@ echo "No data container was defined or bound"
 [% END %]
 export P3_DATA_BIND_DESTINATION="$data_bind_destination"
 
-#
-# Check to see if we have the NFS temp dir available, and bind if so.
-#
-nfs_tmp="/vol/patric3/tmp"
-bigtmp_bind=""
-if [[ -d $nfs_tmp ]] ; then
-    bigtmp_bind=",$nfs_tmp"
-fi
-
 singularity run \
 	    -H $WORKDIR \
 	    --env P3_WORKDIR="$WORKDIR",P3_DATA_CONTAINER="$P3_DATA_CONTAINER",P3_DATA_BIND_DESTINATION="$P3_DATA_BIND_DESTINATION" \
-	    -B $WORKDIR:/tmp${data_bind}${nfs_bindings}${mg_bind}${bigtmp_bind} \
+	    -B $WORKDIR:/tmp${data_bind}${nfs_bindings}${mg_bind} \
 	    --pwd /tmp \
 	    [% container_image %] \
 	    p3x-app-shepherd --app-service [% task.appserv_url %] --task-id [% task.id %] [% task.script %] [% task.monitor_url %] app_spec params &

--- a/service-scripts/p3x-update-qa-results.pl
+++ b/service-scripts/p3x-update-qa-results.pl
@@ -18,7 +18,7 @@ my $cli = Bio::KBase::AppService::Client->new;
 
 my($opt, $usage) = describe_options("%c %o input-file",
 				    ["output-file|o=s" => "Write output here"],
-				    ["html-dir|D=s" => "Write HTML output to this direcotry, named based on the input file"],
+				    ["html-dir|D=s" => "Write HTML output to this directory, named based on the input file"],
 				    ["html-file|H=s" => "Write HTML output here"],
 				    ["help|h" => "Show this help message"]);
 $usage->die() if @ARGV != 1;


### PR DESCRIPTION
Generalize the bindings of NFS volumes into the container with a NFS_bindings list where each
entry is checked for existence then added to the -B bindings list on container startup.

Plus a documentation typo.