### PR TITLE
Update NFS folder binding list

### DIFF
--- a/lib/Bio/KBase/AppService/slurm_batch.tt
+++ b/lib/Bio/KBase/AppService/slurm_batch.tt
@@ -158,7 +158,7 @@ export TEMPDIR=/tmp
 nfs_bindings=""
 mg_bind=""
 
-NFS_bindings="/vol/bvbrc/production/application-backend/bvbrc_ceirr_data_submission /vol/blastdb/bvbrc-service /vol/patric3/tmp"
+NFS_bindings="/vol/bvbrc/production/application-backend /vol/blastdb/bvbrc-service /vol/patric3/tmp"
 for dir in $NFS_bindings ; do
     if [[ -d $dir ]] ; then
 	nfs_bindings="$nfs_bindings,$dir"


### PR DESCRIPTION
Bind the /vol/bvbrc/production/application-backend instead of the per-application folder so we can add new applications without updating scheduler.