### PR TITLE
Add support for per-application default containers

### DIFF
--- a/lib/Bio/KBase/AppService/Schema.sql
+++ b/lib/Bio/KBase/AppService/Schema.sql
@@ -110,6 +110,14 @@ CREATE TABLE Application
 	display_order INTEGER
 );
 
+DROP TABLE IF EXISTS ApplicationDefaultContainer;
+CREATE TABLE ApplicationDefaultContainer
+(
+	application_id VARCHAR(255) PRIMARY KEY,
+	default_container_id VARCHAR(2155),
+	FOREIGN KEY (default_container_id) REFERENCES Container(id)
+);
+
 DROP TABLE IF EXISTS  ApplicationSpec;
 CREATE TABLE ApplicationSpec
 (

--- a/lib/Bio/KBase/AppService/Schema/Result/AllTask.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/AllTask.pm
@@ -1,12 +1,12 @@
 use utf8;
-package Bio::KBase::AppService::Schema::Result::MergedTaskStatus;
+package Bio::KBase::AppService::Schema::Result::AllTask;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE
 
 =head1 NAME
 
-Bio::KBase::AppService::Schema::Result::MergedTaskStatus - VIEW
+Bio::KBase::AppService::Schema::Result::AllTask - VIEW
 
 =cut
 
@@ -28,19 +28,31 @@ use base 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 
-=head1 TABLE: C<MergedTaskStatus>
+=head1 TABLE: C<AllTasks>
 
 =cut
 
-__PACKAGE__->table("MergedTaskStatus");
+__PACKAGE__->table("AllTasks");
 
 =head1 ACCESSORS
 
 =head2 id
 
   data_type: 'integer'
-  default_value: 0
   is_nullable: 0
+
+=head2 submit_time
+
+  data_type: 'timestamp'
+  datetime_undef_if_invalid: 1
+  default_value: '1970-01-01 00:00:00'
+  is_nullable: 0
+
+=head2 application_id
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
 
 =head2 owner
 
@@ -54,7 +66,7 @@ __PACKAGE__->table("MergedTaskStatus");
   is_nullable: 1
   size: 10
 
-=head2 job_status
+=head2 base_url
 
   data_type: 'varchar'
   is_nullable: 1
@@ -64,18 +76,27 @@ __PACKAGE__->table("MergedTaskStatus");
 
 __PACKAGE__->add_columns(
   "id",
-  { data_type => "integer", default_value => 0, is_nullable => 0 },
+  { data_type => "integer", is_nullable => 0 },
+  "submit_time",
+  {
+    data_type => "timestamp",
+    datetime_undef_if_invalid => 1,
+    default_value => "1970-01-01 00:00:00",
+    is_nullable => 0,
+  },
+  "application_id",
+  { data_type => "varchar", is_nullable => 1, size => 255 },
   "owner",
   { data_type => "varchar", is_nullable => 1, size => 255 },
   "state_code",
   { data_type => "varchar", is_nullable => 1, size => 10 },
-  "job_status",
+  "base_url",
   { data_type => "varchar", is_nullable => 1, size => 255 },
 );
 
 
 # Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ThhihOsi5WsrNLtHOb/e0A
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:g4LBKlXfl139CI097PWuNQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/Application.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/Application.pm
@@ -99,6 +99,21 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
+=head2 application_specs
+
+Type: has_many
+
+Related object: L<Bio::KBase::AppService::Schema::Result::ApplicationSpec>
+
+=cut
+
+__PACKAGE__->has_many(
+  "application_specs",
+  "Bio::KBase::AppService::Schema::Result::ApplicationSpec",
+  { "foreign.application_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 tasks
 
 Type: has_many
@@ -115,8 +130,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-04-09 23:30:45
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:XB+dtHslP8oUodsJsSaLtg
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:PSbV2R+zqDVKDbzyoGkC2w
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/ApplicationDefaultContainer.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/ApplicationDefaultContainer.pm
@@ -1,0 +1,100 @@
+use utf8;
+package Bio::KBase::AppService::Schema::Result::ApplicationDefaultContainer;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Bio::KBase::AppService::Schema::Result::ApplicationDefaultContainer
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime");
+
+=head1 TABLE: C<ApplicationDefaultContainer>
+
+=cut
+
+__PACKAGE__->table("ApplicationDefaultContainer");
+
+=head1 ACCESSORS
+
+=head2 application_id
+
+  data_type: 'varchar'
+  is_nullable: 0
+  size: 255
+
+=head2 default_container_id
+
+  data_type: 'varchar'
+  is_foreign_key: 1
+  is_nullable: 1
+  size: 2155
+
+=cut
+
+__PACKAGE__->add_columns(
+  "application_id",
+  { data_type => "varchar", is_nullable => 0, size => 255 },
+  "default_container_id",
+  { data_type => "varchar", is_foreign_key => 1, is_nullable => 1, size => 2155 },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</application_id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("application_id");
+
+=head1 RELATIONS
+
+=head2 default_container
+
+Type: belongs_to
+
+Related object: L<Bio::KBase::AppService::Schema::Result::Container>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "default_container",
+  "Bio::KBase::AppService::Schema::Result::Container",
+  { id => "default_container_id" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "RESTRICT",
+    on_update     => "RESTRICT",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1C6NyZJcnnRHywk/OjmurQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/lib/Bio/KBase/AppService/Schema/Result/ApplicationSpec.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/ApplicationSpec.pm
@@ -1,0 +1,119 @@
+use utf8;
+package Bio::KBase::AppService::Schema::Result::ApplicationSpec;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Bio::KBase::AppService::Schema::Result::ApplicationSpec
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime");
+
+=head1 TABLE: C<ApplicationSpec>
+
+=cut
+
+__PACKAGE__->table("ApplicationSpec");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'varchar'
+  is_nullable: 0
+  size: 64
+
+=head2 application_id
+
+  data_type: 'varchar'
+  is_foreign_key: 1
+  is_nullable: 1
+  size: 255
+
+=head2 spec
+
+  data_type: 'json'
+  is_nullable: 1
+
+=head2 first_seen
+
+  data_type: 'timestamp'
+  datetime_undef_if_invalid: 1
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns(
+  "id",
+  { data_type => "varchar", is_nullable => 0, size => 64 },
+  "application_id",
+  { data_type => "varchar", is_foreign_key => 1, is_nullable => 1, size => 255 },
+  "spec",
+  { data_type => "json", is_nullable => 1 },
+  "first_seen",
+  {
+    data_type => "timestamp",
+    datetime_undef_if_invalid => 1,
+    is_nullable => 1,
+  },
+);
+
+=head1 PRIMARY KEY
+
+=over 4
+
+=item * L</id>
+
+=back
+
+=cut
+
+__PACKAGE__->set_primary_key("id");
+
+=head1 RELATIONS
+
+=head2 application
+
+Type: belongs_to
+
+Related object: L<Bio::KBase::AppService::Schema::Result::Application>
+
+=cut
+
+__PACKAGE__->belongs_to(
+  "application",
+  "Bio::KBase::AppService::Schema::Result::Application",
+  { id => "application_id" },
+  {
+    is_deferrable => 1,
+    join_type     => "LEFT",
+    on_delete     => "RESTRICT",
+    on_update     => "RESTRICT",
+  },
+);
+
+
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:hz44PaBjkWpWQiewWW9/uQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/lib/Bio/KBase/AppService/Schema/Result/ArchivedTask.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/ArchivedTask.pm
@@ -40,6 +40,11 @@ __PACKAGE__->table("ArchivedTask");
   data_type: 'integer'
   is_nullable: 0
 
+=head2 retry_index
+
+  data_type: 'integer'
+  is_nullable: 0
+
 =head2 owner
 
   data_type: 'varchar'
@@ -105,10 +110,11 @@ __PACKAGE__->table("ArchivedTask");
   data_type: 'json'
   is_nullable: 1
 
-=head2 app_spec
+=head2 app_spec_id
 
-  data_type: 'json'
+  data_type: 'varchar'
   is_nullable: 1
+  size: 64
 
 =head2 req_memory
 
@@ -148,6 +154,12 @@ __PACKAGE__->table("ArchivedTask");
   is_nullable: 1
 
 =head2 container_id
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 255
+
+=head2 data_container_id
 
   data_type: 'varchar'
   is_nullable: 1
@@ -203,16 +215,17 @@ __PACKAGE__->table("ArchivedTask");
   is_nullable: 1
   size: 255
 
-=head2 cancel_requested
+=head2 active
 
   data_type: 'tinyint'
-  default_value: 0
   is_nullable: 1
 
 =cut
 
 __PACKAGE__->add_columns(
   "id",
+  { data_type => "integer", is_nullable => 0 },
+  "retry_index",
   { data_type => "integer", is_nullable => 0 },
   "owner",
   { data_type => "varchar", is_nullable => 1, size => 255 },
@@ -251,8 +264,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "params",
   { data_type => "json", is_nullable => 1 },
-  "app_spec",
-  { data_type => "json", is_nullable => 1 },
+  "app_spec_id",
+  { data_type => "varchar", is_nullable => 1, size => 64 },
   "req_memory",
   { data_type => "varchar", is_nullable => 1, size => 255 },
   "req_cpu",
@@ -268,6 +281,8 @@ __PACKAGE__->add_columns(
   "hidden",
   { data_type => "tinyint", default_value => 0, is_nullable => 1 },
   "container_id",
+  { data_type => "varchar", is_nullable => 1, size => 255 },
+  "data_container_id",
   { data_type => "varchar", is_nullable => 1, size => 255 },
   "base_url",
   { data_type => "varchar", is_nullable => 1, size => 255 },
@@ -287,8 +302,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "exitcode",
   { data_type => "varchar", is_nullable => 1, size => 255 },
-  "cancel_requested",
-  { data_type => "tinyint", default_value => 0, is_nullable => 1 },
+  "active",
+  { data_type => "tinyint", is_nullable => 1 },
 );
 
 =head1 PRIMARY KEY
@@ -299,15 +314,17 @@ __PACKAGE__->add_columns(
 
 =item * L</submit_time>
 
+=item * L</retry_index>
+
 =back
 
 =cut
 
-__PACKAGE__->set_primary_key("id", "submit_time");
+__PACKAGE__->set_primary_key("id", "submit_time", "retry_index");
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-11-03 15:42:34
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:eH6jTPNJNg5C8ccLoQQSYw
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:sunP+OpNbWsE8mjXSO8Bdw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/BySiteStatGather.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/BySiteStatGather.pm
@@ -1,12 +1,12 @@
 use utf8;
-package Bio::KBase::AppService::Schema::Result::StatsGatherUser;
+package Bio::KBase::AppService::Schema::Result::BySiteStatGather;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE
 
 =head1 NAME
 
-Bio::KBase::AppService::Schema::Result::StatsGatherUser - VIEW
+Bio::KBase::AppService::Schema::Result::BySiteStatGather - VIEW
 
 =cut
 
@@ -28,11 +28,11 @@ use base 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 
-=head1 TABLE: C<StatsGatherUser>
+=head1 TABLE: C<BySiteStatsGather>
 
 =cut
 
-__PACKAGE__->table("StatsGatherUser");
+__PACKAGE__->table("BySiteStatsGather");
 
 =head1 ACCESSORS
 
@@ -51,9 +51,16 @@ __PACKAGE__->table("StatsGatherUser");
 
   data_type: 'varchar'
   is_nullable: 1
-  size: 255
+  size: 262
 
-=head2 user_count
+=head2 site
+
+  data_type: 'varchar'
+  default_value: (empty string)
+  is_nullable: 0
+  size: 6
+
+=head2 job_count
 
   data_type: 'bigint'
   default_value: 0
@@ -67,14 +74,16 @@ __PACKAGE__->add_columns(
   "year",
   { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 1 },
   "application_id",
-  { data_type => "varchar", is_nullable => 1, size => 255 },
-  "user_count",
+  { data_type => "varchar", is_nullable => 1, size => 262 },
+  "site",
+  { data_type => "varchar", default_value => "", is_nullable => 0, size => 6 },
+  "job_count",
   { data_type => "bigint", default_value => 0, is_nullable => 0 },
 );
 
 
 # Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UgHip+Vr5M4cBb39fEv4dA
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:N/7IFpTkGHwiUA25FEe7CQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/BySiteStatsGatherCollab.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/BySiteStatsGatherCollab.pm
@@ -1,12 +1,12 @@
 use utf8;
-package Bio::KBase::AppService::Schema::Result::StatsGatherUser;
+package Bio::KBase::AppService::Schema::Result::BySiteStatsGatherCollab;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE
 
 =head1 NAME
 
-Bio::KBase::AppService::Schema::Result::StatsGatherUser - VIEW
+Bio::KBase::AppService::Schema::Result::BySiteStatsGatherCollab - VIEW
 
 =cut
 
@@ -28,11 +28,11 @@ use base 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 
-=head1 TABLE: C<StatsGatherUser>
+=head1 TABLE: C<BySiteStatsGatherCollab>
 
 =cut
 
-__PACKAGE__->table("StatsGatherUser");
+__PACKAGE__->table("BySiteStatsGatherCollab");
 
 =head1 ACCESSORS
 
@@ -51,9 +51,16 @@ __PACKAGE__->table("StatsGatherUser");
 
   data_type: 'varchar'
   is_nullable: 1
-  size: 255
+  size: 262
 
-=head2 user_count
+=head2 site
+
+  data_type: 'varchar'
+  default_value: (empty string)
+  is_nullable: 0
+  size: 6
+
+=head2 job_count
 
   data_type: 'bigint'
   default_value: 0
@@ -67,14 +74,16 @@ __PACKAGE__->add_columns(
   "year",
   { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 1 },
   "application_id",
-  { data_type => "varchar", is_nullable => 1, size => 255 },
-  "user_count",
+  { data_type => "varchar", is_nullable => 1, size => 262 },
+  "site",
+  { data_type => "varchar", default_value => "", is_nullable => 0, size => 6 },
+  "job_count",
   { data_type => "bigint", default_value => 0, is_nullable => 0 },
 );
 
 
 # Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UgHip+Vr5M4cBb39fEv4dA
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:xtwcZUGdSLHyrN4Lfe4CiA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/BySiteStatsGatherNonCollab.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/BySiteStatsGatherNonCollab.pm
@@ -1,12 +1,12 @@
 use utf8;
-package Bio::KBase::AppService::Schema::Result::StatsGatherUser;
+package Bio::KBase::AppService::Schema::Result::BySiteStatsGatherNonCollab;
 
 # Created by DBIx::Class::Schema::Loader
 # DO NOT MODIFY THE FIRST PART OF THIS FILE
 
 =head1 NAME
 
-Bio::KBase::AppService::Schema::Result::StatsGatherUser - VIEW
+Bio::KBase::AppService::Schema::Result::BySiteStatsGatherNonCollab - VIEW
 
 =cut
 
@@ -28,11 +28,11 @@ use base 'DBIx::Class::Core';
 __PACKAGE__->load_components("InflateColumn::DateTime");
 __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 
-=head1 TABLE: C<StatsGatherUser>
+=head1 TABLE: C<BySiteStatsGatherNonCollab>
 
 =cut
 
-__PACKAGE__->table("StatsGatherUser");
+__PACKAGE__->table("BySiteStatsGatherNonCollab");
 
 =head1 ACCESSORS
 
@@ -53,7 +53,14 @@ __PACKAGE__->table("StatsGatherUser");
   is_nullable: 1
   size: 255
 
-=head2 user_count
+=head2 site
+
+  data_type: 'varchar'
+  default_value: (empty string)
+  is_nullable: 0
+  size: 6
+
+=head2 job_count
 
   data_type: 'bigint'
   default_value: 0
@@ -68,13 +75,15 @@ __PACKAGE__->add_columns(
   { data_type => "integer", extra => { unsigned => 1 }, is_nullable => 1 },
   "application_id",
   { data_type => "varchar", is_nullable => 1, size => 255 },
-  "user_count",
+  "site",
+  { data_type => "varchar", default_value => "", is_nullable => 0, size => 6 },
+  "job_count",
   { data_type => "bigint", default_value => 0, is_nullable => 0 },
 );
 
 
 # Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:UgHip+Vr5M4cBb39fEv4dA
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:OEHS8bAFvllOYYMg322mDw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/ComputeWaitRunTime.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/ComputeWaitRunTime.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("compute_wait_run_time");
-__PACKAGE__->result_source_instance->view_definition("select `AppService`.`Task`.`id` AS `id`,`AppService`.`Task`.`application_id` AS `application_id`,`AppService`.`Task`.`state_code` AS `state_code`,timediff(`AppService`.`Task`.`start_time`,`AppService`.`Task`.`submit_time`) AS `wait`,timediff(`AppService`.`Task`.`finish_time`,`AppService`.`Task`.`start_time`) AS `run` from `AppService`.`Task` where (`AppService`.`Task`.`state_code` = 'C')");
 
 =head1 ACCESSORS
 
@@ -81,8 +80,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-10 14:48:59
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9mzdlrXOUyGWNEyNBsLdnQ
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:9ZCoOlSnXX6azxoINnMCrg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/Container.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/Container.pm
@@ -84,6 +84,21 @@ __PACKAGE__->set_primary_key("id");
 
 =head1 RELATIONS
 
+=head2 application_default_containers
+
+Type: has_many
+
+Related object: L<Bio::KBase::AppService::Schema::Result::ApplicationDefaultContainer>
+
+=cut
+
+__PACKAGE__->has_many(
+  "application_default_containers",
+  "Bio::KBase::AppService::Schema::Result::ApplicationDefaultContainer",
+  { "foreign.default_container_id" => "self.id" },
+  { cascade_copy => 0, cascade_delete => 0 },
+);
+
 =head2 clusters
 
 Type: has_many
@@ -130,8 +145,8 @@ __PACKAGE__->has_many(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-10 14:48:58
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:zKU7umgQVJu/abgHhqGryQ
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:yMBHh7KePEMovImxZup0pA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/StatGather.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/StatGather.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("StatsGather");
-__PACKAGE__->result_source_instance->view_definition("select `StatsGatherCollab`.`month` AS `month`,`StatsGatherCollab`.`year` AS `year`,`StatsGatherCollab`.`application_id` AS `application_id`,`StatsGatherCollab`.`job_count` AS `job_count` from `AppService`.`StatsGatherCollab` union select `StatsGatherNonCollab`.`month` AS `month`,`StatsGatherNonCollab`.`year` AS `year`,`StatsGatherNonCollab`.`application_id` AS `application_id`,`StatsGatherNonCollab`.`job_count` AS `job_count` from `AppService`.`StatsGatherNonCollab` order by `year`,`month`,`application_id`");
 
 =head1 ACCESSORS
 
@@ -74,8 +73,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-04-09 23:30:46
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MeidYciRKYrYhVUW1vpZMg
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:ehPAk4zVfAzkJHyB5NKVpQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/StatGatherAll.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/StatGatherAll.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("StatsGatherAll");
-__PACKAGE__->result_source_instance->view_definition("select month(`t`.`submit_time`) AS `month`,year(`t`.`submit_time`) AS `year`,`t`.`application_id` AS `application_id`,count(`t`.`id`) AS `job_count` from (`AppService`.`Task` `t` join `AppService`.`ServiceUser` `u` on((`t`.`owner` = `u`.`id`))) where ((`t`.`application_id` not in ('Date','Sleep')) and (`t`.`state_code` = 'C')) group by month(`t`.`submit_time`),year(`t`.`submit_time`),`t`.`application_id` order by year(`t`.`submit_time`),month(`t`.`submit_time`),`t`.`application_id`");
 
 =head1 ACCESSORS
 
@@ -74,8 +73,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-04-09 23:30:46
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:4MHTj6jNjjnoxP6vC/IOcw
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vV9UXI1VBP31mGZOmzFUwg
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/StatsGatherCollab.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/StatsGatherCollab.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("StatsGatherCollab");
-__PACKAGE__->result_source_instance->view_definition("select month(`t`.`submit_time`) AS `month`,year(`t`.`submit_time`) AS `year`,concat(`t`.`application_id`,'-collab') AS `application_id`,count(`t`.`id`) AS `job_count` from (`AppService`.`Task` `t` join `AppService`.`ServiceUser` `u` on((`t`.`owner` = `u`.`id`))) where ((`t`.`application_id` in ('GenomeAssembly','GenomeAssembly2','GenomeAnnotation')) and (`u`.`is_collaborator` = 1) and (`u`.`is_staff` = 0) and (`t`.`state_code` = 'C')) group by month(`t`.`submit_time`),year(`t`.`submit_time`),`t`.`application_id` order by year(`t`.`submit_time`),month(`t`.`submit_time`),`t`.`application_id`");
 
 =head1 ACCESSORS
 
@@ -74,8 +73,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-04-09 23:30:46
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:QTVNmHCwqo6zTv1Or4vszg
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:MNy4J3tr4Xq24r/ST9VBYw
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/StatsGatherNonCollab.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/StatsGatherNonCollab.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("StatsGatherNonCollab");
-__PACKAGE__->result_source_instance->view_definition("select month(`t`.`submit_time`) AS `month`,year(`t`.`submit_time`) AS `year`,`t`.`application_id` AS `application_id`,count(`t`.`id`) AS `job_count` from (`AppService`.`Task` `t` join `AppService`.`ServiceUser` `u` on((`t`.`owner` = `u`.`id`))) where ((`t`.`application_id` not in ('Date','Sleep')) and (`u`.`is_collaborator` = 0) and (`u`.`is_staff` = 0) and (`t`.`state_code` = 'C')) group by month(`t`.`submit_time`),year(`t`.`submit_time`),`t`.`application_id` order by year(`t`.`submit_time`),month(`t`.`submit_time`),`t`.`application_id`");
 
 =head1 ACCESSORS
 
@@ -74,8 +73,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2020-04-09 23:30:46
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:vS30WOvGUGjByW589+DDPA
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:f3zY8HguN94cU8I++K7mEA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/TaskForArchiving.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/TaskForArchiving.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("TasksForArchiving");
-__PACKAGE__->result_source_instance->view_definition("select `t`.`id` AS `id`,`t`.`owner` AS `owner`,`t`.`parent_task` AS `parent_task`,`t`.`state_code` AS `state_code`,`t`.`application_id` AS `application_id`,`t`.`submit_time` AS `submit_time`,`t`.`start_time` AS `start_time`,`t`.`finish_time` AS `finish_time`,`t`.`monitor_url` AS `monitor_url`,`t`.`output_path` AS `output_path`,`t`.`output_file` AS `output_file`,if(json_valid(`t`.`params`),`t`.`params`,'{}') AS `params`,if(json_valid(`t`.`app_spec`),`t`.`app_spec`,'{}') AS `app_spec`,`t`.`req_memory` AS `req_memory`,`t`.`req_cpu` AS `req_cpu`,`t`.`req_runtime` AS `req_runtime`,`t`.`req_policy_data` AS `req_policy_data`,`t`.`req_is_control_task` AS `req_is_control_task`,`t`.`search_terms` AS `search_terms`,`t`.`hidden` AS `hidden`,`t`.`container_id` AS `container_id`,`t`.`base_url` AS `base_url`,`t`.`user_metadata` AS `user_metadata`,`cj`.`id` AS `cluster_job_id`,`cj`.`cluster_id` AS `cluster_id`,`cj`.`job_id` AS `job_id`,`cj`.`job_status` AS `job_status`,`cj`.`maxrss` AS `maxrss`,`cj`.`nodelist` AS `nodelist`,`cj`.`exitcode` AS `exitcode`,`cj`.`cancel_requested` AS `cancel_requested` from ((`AppService`.`Task` `t` left join `AppService`.`TaskExecution` `te` on((`t`.`id` = `te`.`task_id`))) left join `AppService`.`ClusterJob` `cj` on((`cj`.`id` = `te`.`cluster_job_id`))) where (isnull(`te`.`active`) or (`te`.`active` = 1))");
 
 =head1 ACCESSORS
 
@@ -112,6 +111,12 @@ __PACKAGE__->result_source_instance->view_definition("select `t`.`id` AS `id`,`t
 
   data_type: 'text'
   is_nullable: 1
+
+=head2 app_spec_id
+
+  data_type: 'varchar'
+  is_nullable: 1
+  size: 64
 
 =head2 req_memory
 
@@ -257,6 +262,8 @@ __PACKAGE__->add_columns(
   { data_type => "text", is_nullable => 1 },
   "app_spec",
   { data_type => "text", is_nullable => 1 },
+  "app_spec_id",
+  { data_type => "varchar", is_nullable => 1, size => 64 },
   "req_memory",
   { data_type => "varchar", is_nullable => 1, size => 255 },
   "req_cpu",
@@ -296,8 +303,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-11-03 15:42:34
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:GOWFrqWBmnbz8JUTaPoKfg
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:NAZh7a/S7Dp5y/t1nIo8eA
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/TaskWithActiveJob.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/TaskWithActiveJob.pm
@@ -33,7 +33,6 @@ __PACKAGE__->table_class("DBIx::Class::ResultSource::View");
 =cut
 
 __PACKAGE__->table("TaskWithActiveJob");
-__PACKAGE__->result_source_instance->view_definition("select `t`.`id` AS `id`,`t`.`owner` AS `owner`,`t`.`parent_task` AS `parent_task`,`t`.`state_code` AS `state_code`,`t`.`application_id` AS `application_id`,`t`.`submit_time` AS `submit_time`,`t`.`start_time` AS `start_time`,`t`.`finish_time` AS `finish_time`,`t`.`monitor_url` AS `monitor_url`,`t`.`params` AS `params`,`t`.`app_spec` AS `app_spec`,`t`.`req_memory` AS `req_memory`,`t`.`req_cpu` AS `req_cpu`,`t`.`req_runtime` AS `req_runtime`,`t`.`req_policy_data` AS `req_policy_data`,`t`.`output_path` AS `output_path`,`t`.`output_file` AS `output_file`,`t`.`req_is_control_task` AS `req_is_control_task`,`t`.`search_terms` AS `search_terms`,`t`.`hidden` AS `hidden`,`cj`.`id` AS `cluster_job_id`,`cj`.`cluster_id` AS `cluster_id`,`cj`.`job_id` AS `cluster_job`,`cj`.`job_status` AS `job_status`,`cj`.`exitcode` AS `exitcode`,`cj`.`nodelist` AS `nodelist`,`cj`.`maxrss` AS `maxrss`,`cj`.`cancel_requested` AS `cancel_requested` from ((`AppService`.`Task` `t` join `AppService`.`TaskExecution` `te` on((`t`.`id` = `te`.`task_id`))) join `AppService`.`ClusterJob` `cj` on((`cj`.`id` = `te`.`cluster_job_id`))) where (`te`.`active` = 1)");
 
 =head1 ACCESSORS
 
@@ -273,8 +272,8 @@ __PACKAGE__->add_columns(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-03-10 14:48:59
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:JpRTElhp6W+ZikcX6MLn1A
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:QM/tbeiV/cJlpBdi0ms31A
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/lib/Bio/KBase/AppService/Schema/Result/Xtest.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/Xtest.pm
@@ -1,0 +1,53 @@
+use utf8;
+package Bio::KBase::AppService::Schema::Result::Xtest;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Bio::KBase::AppService::Schema::Result::Xtest
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime");
+
+=head1 TABLE: C<xtest>
+
+=cut
+
+__PACKAGE__->table("xtest");
+
+=head1 ACCESSORS
+
+=head2 s
+
+  data_type: 'text'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns("s", { data_type => "text", is_nullable => 1 });
+
+
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:27
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:TJ525d6wRTLvjl2dTcz8zQ
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;

--- a/lib/Bio/KBase/AppService/Schema/Result/Y.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/Y.pm
@@ -1,0 +1,53 @@
+use utf8;
+package Bio::KBase::AppService::Schema::Result::Y;
+
+# Created by DBIx::Class::Schema::Loader
+# DO NOT MODIFY THE FIRST PART OF THIS FILE
+
+=head1 NAME
+
+Bio::KBase::AppService::Schema::Result::Y
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class::Core';
+
+=head1 COMPONENTS LOADED
+
+=over 4
+
+=item * L<DBIx::Class::InflateColumn::DateTime>
+
+=back
+
+=cut
+
+__PACKAGE__->load_components("InflateColumn::DateTime");
+
+=head1 TABLE: C<y>
+
+=cut
+
+__PACKAGE__->table("y");
+
+=head1 ACCESSORS
+
+=head2 id
+
+  data_type: 'integer'
+  is_nullable: 1
+
+=cut
+
+__PACKAGE__->add_columns("id", { data_type => "integer", is_nullable => 1 });
+
+
+# Created by DBIx::Class::Schema::Loader v0.07052 @ 2024-04-18 10:56:28
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:M2qgdK9Dif/ug4sxZEyr1w
+
+
+# You can replace this text with custom code or comments, and it will be preserved on regeneration
+1;


### PR DESCRIPTION
Add the ApplicationDefaultContainer to the scheduler database. Entries here will override the site default container, but still can be overridden by task-specific container specification.

Note that with the rebuild of the DBIx::Class schema objects the view definition data for views was lost. It is unclear why, but should not be an issue. if it is the files in question can be reverted to the version prior to this PR.