### PR TITLE
  Summary of All Changes

### DIFF
--- a/lib/Bio/KBase/AppService/SlurmCluster.pm
+++ b/lib/Bio/KBase/AppService/SlurmCluster.pm
@@ -1073,7 +1073,7 @@ sub queue_check
 	    #
 	    for my $task ($cj->tasks)
 	    {
-		$self->scheduler->invalidate_user_cache($task->owner);
+		$self->scheduler->invalidate_user_cache($task->owner->id);
 		$task->update({
 		    state_code => $code,
 		    ($vals->{Start} =~ /\d+/ ? (start_time => $vals->{Start}) : ()),
@@ -1104,7 +1104,7 @@ sub queue_check
 		{
 		    for my $task ($cj->tasks)
 		    {
-			$self->scheduler->invalidate_user_cache($task->owner);
+			$self->scheduler->invalidate_user_cache($task->owner->id);
 			$task->update({
 			    start_time => $vals->{Start},
 			});


### PR DESCRIPTION
  1. SlurmCluster.pm:1076, 1107 - BUG FIX

  Changed $task->owner to $task->owner->id so the correct cache key is used when invalidating on status changes.

  2. Scheduler.pm:339-342 - New feature

  Added cache invalidation when a job is submitted via start_app().

  3. p3x-submit-job.pl:139-148 - New feature

  Added cache invalidation when a job is submitted via the command-line script.

  The main issue was that cache invalidation on job status changes (running, completed) was never working because it was deleting the wrong Redis key.