### PR TITLE
● Fixed. Now the cache is invalidated whenever the job status changes…

### DIFF
--- a/lib/Bio/KBase/AppService/SlurmCluster.pm
+++ b/lib/Bio/KBase/AppService/SlurmCluster.pm
@@ -1100,11 +1100,14 @@ sub queue_check
 		    job_status => $vals->{State},
 		    ($vals->{NodeList} ne '' ? (nodelist => $vals->{NodeList}) : ()),
 		});
-		if ($vals->{Start})
+		#
+		# Invalidate cache for all tasks when job status changes
+		#
+		for my $task ($cj->tasks)
 		{
-		    for my $task ($cj->tasks)
+		    $self->scheduler->invalidate_user_cache($task->owner->id);
+		    if ($vals->{Start})
 		    {
-			$self->scheduler->invalidate_user_cache($task->owner->id);
 			$task->update({
 			    start_time => $vals->{Start},
 			});


### PR DESCRIPTION
… (e.g., from "Queued" to "Running"), regardless of whether the start time is available. The start_time update is now conditional inside the loop instead of the cache invalidation being conditional.