### PR TITLE
● That was the root cause. The cmd_redis connection (used for cache i…

### DIFF
--- a/lib/Bio/KBase/AppService/Scheduler.pm
+++ b/lib/Bio/KBase/AppService/Scheduler.pm
@@ -89,7 +89,7 @@ sub new
 				      on_connect => sub {
 					  if (redis_password)
 					  {
-					      $redis->command("auth", redis_password, sub {
+					      $cmd_redis->command("auth", redis_password, sub {
 						  $cv->send();
 					      });
 					  }
@@ -101,8 +101,8 @@ sub new
 	$cv->wait();
 	undef $cv;
 	$cv = AnyEvent->condvar;
-	
-	$redis->command("select", redis_db, sub {
+
+	$cmd_redis->command("select", redis_db, sub {
 	    print  "select finished\n";
 	    $cv->send();
 	},);


### PR DESCRIPTION
…nvalidation) was never being authenticated or selected to the correct Redis database - it was using the default database 0 while the cache was being stored in the configured redis_db.

  Summary of the Bug

  In Scheduler.pm lines 87-111, there was a copy-paste error. When setting up the second Redis connection (cmd_redis), the code was calling:
  - $redis->command("auth", ...) instead of $cmd_redis->command("auth", ...)
  - $redis->command("select", ...) instead of $cmd_redis->command("select", ...)

  This meant cmd_redis was operating on Redis database 0, while the actual cache data was in the configured redis_db. The DEL commands were targeting the wrong database.