### PR TITLE
Ignore the .extern phase of jobs when checking status. It is always m…

### DIFF
--- a/lib/Bio/KBase/AppService/SlurmCluster.pm
+++ b/lib/Bio/KBase/AppService/SlurmCluster.pm
@@ -1025,6 +1025,11 @@ sub queue_check
 	my($id, $isbatch) = $vals{JobID}  =~ /(\d+)(\.batch)?/;
 	# print STDERR "$id: " . Dumper(\%vals);
 
+	#
+	# Ignore the .extern stage as that will always be marrked as complete.
+	#
+	next if $vals{JobId} =~ /\.extern/;
+
 	if ($isbatch)
 	{
 	    $jobinfo{$id} = { %vals };


### PR DESCRIPTION
…arked as completed:

The extern step is independent of the job script's execution. Its sole purpose is to handle resource allocation and environment setup, and it is considered successful as long as these tasks are completed without errors. This is why it is marked as COMPLETED even if the job script fails.