### PR TITLE
Update Slurm batch options for PyTorch Lightning compatibility

### DIFF
--- a/lib/Bio/KBase/AppService/slurm_batch.tt
+++ b/lib/Bio/KBase/AppService/slurm_batch.tt
@@ -2,7 +2,7 @@
 #SBATCH --account [% sbatch_account %]
 #SBATCH --job-name [% sbatch_job_name %]
 #SBATCH --mem [% sbatch_job_mem %]
-#SBATCH --nodes 1-1 --ntasks [% n_cpus %]
+#SBATCH --nodes=1 --ntasks-per-node=[% n_cpus %]
 #SBATCH --export NONE
 #SBATCH --comment "[% tasks.0.app.id %]"
 [% sbatch_constraint %]


### PR DESCRIPTION
Change from "--nodes 1-1 --ntasks [n_cpus]" to "--nodes=1 --ntasks-per-node=[n_cpus]"

PyTorch Lightning requires --ntasks-per-node for proper distributed training configuration. The previous --ntasks option does not explicitly specify per-node task allocation, which can cause issues with PyTorch Lightning's automatic detection of available resources for multi-GPU or distributed training setups.

Analysis of side effects:
- Syntax change (--nodes=1 vs --nodes 1-1): Equivalent, no functional difference
- --ntasks vs --ntasks-per-node: Both work for single-node jobs, but --ntasks-per-node is more explicit about per-node allocation

The P3_ALLOCATED_CPU environment variable (used by 30+ applications for parallelism settings including genome annotation, assembly, RNASeq, homology searches, and metagenomic binning) is set via SLURM_JOB_CPUS_PER_NODE, which should continue to work correctly with this change. The SLURM_MEM_PER_NODE variable for P3_ALLOCATED_MEMORY is unaffected.