### PR TITLE
Add site-specific container overrides and storage option for job reset

### DIFF
--- a/lib/Bio/KBase/AppService/SchedulerDB.pm
+++ b/lib/Bio/KBase/AppService/SchedulerDB.pm
@@ -1364,8 +1364,25 @@ sub reset_job
 	    $res = $self->dbh->do($qry, undef,  @params, $job);
 	}
 	print STDERR "Update returns $res\n";
+
+	if ($reset_params->{storage})
+	{
+	    my $row = $self->dbh->selectrow_arrayref(qq(SELECT params FROM Task WHERE id = ?), undef, $job);
+	    if ($row && $row->[0])
+	    {
+		my $params = eval { $self->json->decode($row->[0]) };
+		if (ref($params) eq 'HASH')
+		{
+		    $params->{_preflight} //= {};
+		    $params->{_preflight}->{storage} = $reset_params->{storage} + 0;
+		    my $new_params = $self->json->encode($params);
+		    $self->dbh->do(qq(UPDATE Task SET params = ? WHERE id = ?), undef, $new_params, $job);
+		    print STDERR "Updated storage to $reset_params->{storage} for job $job\n";
+		}
+	    }
+	}
     }
-							    
+
 }
 
 1;

--- a/lib/Bio/KBase/AppService/Schema/Result/ApplicationDefaultContainer.pm
+++ b/lib/Bio/KBase/AppService/Schema/Result/ApplicationDefaultContainer.pm
@@ -41,6 +41,13 @@ __PACKAGE__->table("ApplicationDefaultContainer");
   is_nullable: 0
   size: 255
 
+=head2 site_type
+
+  data_type: 'varchar'
+  is_nullable: 0
+  default_value: ''
+  size: 255
+
 =head2 default_container_id
 
   data_type: 'varchar'
@@ -53,6 +60,8 @@ __PACKAGE__->table("ApplicationDefaultContainer");
 __PACKAGE__->add_columns(
   "application_id",
   { data_type => "varchar", is_nullable => 0, size => 255 },
+  "site_type",
+  { data_type => "varchar", is_nullable => 0, default_value => '', size => 255 },
   "default_container_id",
   { data_type => "varchar", is_foreign_key => 1, is_nullable => 1, size => 2155 },
 );
@@ -63,11 +72,13 @@ __PACKAGE__->add_columns(
 
 =item * L</application_id>
 
+=item * L</site_type>
+
 =back
 
 =cut
 
-__PACKAGE__->set_primary_key("application_id");
+__PACKAGE__->set_primary_key("application_id", "site_type");
 
 =head1 RELATIONS
 

--- a/lib/Bio/KBase/AppService/SlurmCluster.pm
+++ b/lib/Bio/KBase/AppService/SlurmCluster.pm
@@ -529,13 +529,14 @@ sub build_submission_for_tasks
     #
     # P3_CONTAINER hard override
     # Container setting from the Task being scheduled
-    # Container setting from the ApplicationDefaultContainer for the Task's application
+    # Container setting from the ApplicationDefaultContainer for the Task's application + site_type
+    # Container setting from the ApplicationDefaultContainer for the Task's application (global)
     # Container setting from the SiteDefaultContainer for the site the Task was submitted from
     # Cluster default container
     #
 
     local $Data::Dumper::Maxdepth = 1;
-    
+
     if ($ENV{P3_CONTAINER})
     {
 	$vars{container_image} = $ENV{P3_CONTAINER};
@@ -551,31 +552,60 @@ sub build_submission_for_tasks
 
 	my $container = $task->container;
 
+	#
+	# Look up site_type from SiteDefaultContainer using base_url
+	#
+	my $site_type;
+	my $site_default_container;
+	if ($base_url)
+	{
+	    my $site_default = $self->schema->resultset("SiteDefaultContainer")->find($base_url);
+	    if ($site_default)
+	    {
+		$site_type = $site_default->site_type;
+		$site_default_container = $site_default->default_container;
+	    }
+	}
+
 	if (!$container)
 	{
 	    #
-	    # Query the application default container table for a app-default container.
+	    # Query the application default container table for an app + site_type specific container.
 	    #
-	    my $app_default = $self->schema->resultset('ApplicationDefaultContainer')->find($task->application_id);
+	    if ($site_type)
+	    {
+		my $app_site_default = $self->schema->resultset('ApplicationDefaultContainer')
+		    ->find({ application_id => $task->application_id, site_type => $site_type });
+		if ($app_site_default)
+		{
+		    $container = $app_site_default->default_container;
+		    print STDERR "Choosing container " . $container->id . " for " . $task->id .
+			" due to default container for app " . $task->application_id . " + site_type $site_type\n";
+		}
+	    }
+	}
+
+	if (!$container)
+	{
+	    #
+	    # Query the application default container table for a global app-default container (site_type='').
+	    #
+	    my $app_default = $self->schema->resultset('ApplicationDefaultContainer')
+		->find({ application_id => $task->application_id, site_type => '' });
 	    if ($app_default)
 	    {
 		$container = $app_default->default_container;
-		print STDERR "Choosing container " . $container->id . " for " . $task->id . " due to default container for app " . $task->application_id . "\n";
+		print STDERR "Choosing container " . $container->id . " for " . $task->id .
+		    " due to global default container for app " . $task->application_id . "\n";
 	    }
 	}
+
 	if (!$container)
 	{
 	    #
-	    # If we have a base url set, determine if we have a container defined for it.
+	    # Fall back to site default container
 	    #
-	    if ($base_url)
-	    {
-		my $site_default = $self->schema->resultset("SiteDefaultContainer")->find($base_url);
-		if ($site_default)
-		{
-		    $container = $site_default->default_container;
-		}
-	    }
+	    $container = $site_default_container;
 	}
 	$container //= $cinfo->default_container;
 	if ($container)

--- a/service-scripts/p3x-add-container.pl
+++ b/service-scripts/p3x-add-container.pl
@@ -1,0 +1,96 @@
+=head1 NAME
+
+    p3x-add-container - add a new container image to the scheduler database
+
+=head1 SYNOPSIS
+
+    p3x-add-container [OPTION] container-id
+
+=head1 DESCRIPTION
+
+Adds a new container image ID to the Container table in the scheduler database.
+
+The container ID must not already exist in the database. The image filename
+defaults to the container ID with a ".sif" suffix. The existence of the
+image file in /vol/patric3/production/containers is verified before adding.
+
+=cut
+
+use strict;
+use Data::Dumper;
+use Bio::KBase::AppService::SchedulerDB;
+
+use Getopt::Long::Descriptive;
+
+my $default_container_dir = "/vol/patric3/production/containers";
+
+my($opt, $usage) = describe_options("%c %o container-id",
+				    ["filename|f=s" => "Override the default filename (container-id.sif)"],
+				    ["container-dir|d=s" => "Container directory (default: $default_container_dir)",
+				     { default => $default_container_dir }],
+				    ["force" => "Add even if file does not exist (not recommended)"],
+				    ["help|h" => "Show this help message."],
+				    );
+print($usage->text), exit 0 if $opt->help;
+die($usage->text) if @ARGV != 1;
+
+my $container_id = shift;
+
+#
+# Validate container ID format - should be reasonable identifier
+#
+if ($container_id !~ /^[\w.-]+$/)
+{
+    die "Invalid container ID '$container_id': must contain only alphanumeric characters, dots, underscores, and hyphens\n";
+}
+
+#
+# Determine filename
+#
+my $filename = $opt->filename // "$container_id.sif";
+
+#
+# Verify image file exists
+#
+my $container_path = $opt->container_dir . "/" . $filename;
+if (!-f $container_path)
+{
+    if ($opt->force)
+    {
+	warn "Warning: Container image file $container_path does not exist (proceeding due to --force)\n";
+    }
+    else
+    {
+	die "Container image file $container_path does not exist\n";
+    }
+}
+
+my $db = Bio::KBase::AppService::SchedulerDB->new();
+
+#
+# Check if container ID already exists
+#
+my $existing = $db->dbh->selectrow_arrayref(
+    qq(SELECT id, filename FROM Container WHERE id = ?),
+    undef, $container_id
+);
+
+if ($existing)
+{
+    die "Container ID '$container_id' already exists in database with filename '$existing->[1]'\n";
+}
+
+#
+# Insert the new container record
+#
+my $res = $db->dbh->do(
+    qq(INSERT INTO Container (id, filename) VALUES (?, ?)),
+    undef, $container_id, $filename
+);
+
+if ($res != 1)
+{
+    die "Failed to insert container record\n";
+}
+
+print "Added container '$container_id' with filename '$filename'\n";

--- a/service-scripts/p3x-reset-job.pl
+++ b/service-scripts/p3x-reset-job.pl
@@ -24,6 +24,7 @@ my($opt, $usage) = describe_options("%c %o",
 				    ["time|t=s" => "Reset the requested duration"],
 				    ["memory|m=s" => "Reset the requested memory"],
 				    ["cpu|c=s" => "Reset the requested number of cpus"],
+				    ["storage|s=s" => "Reset the requested storage (bytes)"],
 				    ["data-container|D=s" => "Reset the requested data container"],
 				    ["container|C=s" => "Reset the requested runtime container"],
 				    ["help|h" => "Show this help message."],
@@ -44,6 +45,25 @@ elsif ($opt->time)
 {
     $time = eval { parse_duration($opt->time); };
     die "Cannot parse '" . $opt->time . "'" unless defined($time);
+}
+
+my $storage;
+if ($opt->storage)
+{
+    my $s = $opt->storage;
+    if ($s =~ /^(\d+(?:\.\d+)?)\s*([TGMK])B?$/i)
+    {
+	my %mult = (T => 1e12, G => 1e9, M => 1e6, K => 1e3);
+	$storage = int($1 * $mult{uc $2});
+    }
+    elsif ($s =~ /^\d+$/)
+    {
+	$storage = $s + 0;
+    }
+    else
+    {
+	die "Cannot parse storage '$s' (use e.g. 50G, 1.5T, 500M, or bytes)\n";
+    }
 }
 
 my $db = Bio::KBase::AppService::SchedulerDB->new();
@@ -68,6 +88,7 @@ for my $task (@task_ids)
        ($time ? (time => $time) : ()),
        ($opt->memory ? (memory => $opt->memory) : ()),
        ($opt->cpu ? (cpu => $opt->cpu) : ()),
+       ($storage ? (storage => $storage) : ()),
        ($opt->data_container ? (data_container_id => $opt->data_container) : ()),
        ($opt->container ? (container_id => $opt->container) : ()),
    });

--- a/service-scripts/p3x-set-app-container.pl
+++ b/service-scripts/p3x-set-app-container.pl
@@ -1,0 +1,206 @@
+=head1 NAME
+
+    p3x-set-app-container - set the default container for an application
+
+=head1 SYNOPSIS
+
+    p3x-set-app-container [OPTION] app-id container-id
+
+=head1 DESCRIPTION
+
+Sets or updates the default container ID for an application in the
+ApplicationDefaultContainer table.
+
+The container ID must exist in the Container table. If the application
+already has a default container configured, it will be updated to the
+new container ID.
+
+Use --site-type to set a container override for a specific site type
+(e.g., alpha, beta, prod). Without --site-type, sets the global default
+for the application.
+
+=cut
+
+use strict;
+use Data::Dumper;
+use Bio::KBase::AppService::SchedulerDB;
+
+use Getopt::Long::Descriptive;
+
+my($opt, $usage) = describe_options("%c %o app-id container-id",
+				    ["site-type|s=s" => "Site type (e.g., alpha, beta, prod) for site-specific override"],
+				    ["list|l" => "List all application default containers"],
+				    ["remove|r" => "Remove the default container for the app (container-id not required)"],
+				    ["help|h" => "Show this help message."],
+				    );
+print($usage->text), exit 0 if $opt->help;
+
+my $db = Bio::KBase::AppService::SchedulerDB->new();
+
+if ($opt->list)
+{
+    my $res = $db->dbh->selectall_arrayref(
+	qq(SELECT adc.application_id, adc.site_type, adc.default_container_id, c.filename
+	   FROM ApplicationDefaultContainer adc
+	   LEFT JOIN Container c ON adc.default_container_id = c.id
+	   ORDER BY adc.application_id, adc.site_type),
+	{ Slice => {} }
+    );
+
+    if (@$res == 0)
+    {
+	print "No application default containers configured.\n";
+    }
+    else
+    {
+	printf "%-35s %-12s %-35s %s\n", "Application", "Site Type", "Container ID", "Filename";
+	printf "%-35s %-12s %-35s %s\n", "-" x 35, "-" x 12, "-" x 35, "-" x 30;
+	for my $row (@$res)
+	{
+	    printf "%-35s %-12s %-35s %s\n",
+		$row->{application_id},
+		$row->{site_type} eq '' ? "(global)" : $row->{site_type},
+		$row->{default_container_id} // "(none)",
+		$row->{filename} // "";
+	}
+    }
+    exit 0;
+}
+
+my $site_type = $opt->site_type // '';
+
+if ($opt->remove)
+{
+    die($usage->text) if @ARGV != 1;
+    my $app_id = shift;
+
+    #
+    # Validate site_type if specified
+    #
+    if ($site_type ne '')
+    {
+	my $valid_site_types = $db->dbh->selectcol_arrayref(
+	    qq(SELECT DISTINCT site_type FROM SiteDefaultContainer WHERE site_type IS NOT NULL)
+	);
+	my %valid = map { $_ => 1 } @$valid_site_types;
+
+	if (!$valid{$site_type})
+	{
+	    my $valid_list = join(", ", sort @$valid_site_types);
+	    die "Invalid site_type '$site_type'.\n" .
+		"Valid site_type values are: $valid_list\n";
+	}
+    }
+
+    my $res = $db->dbh->do(
+	qq(DELETE FROM ApplicationDefaultContainer WHERE application_id = ? AND site_type = ?),
+	undef, $app_id, $site_type
+    );
+
+    if ($res == 0)
+    {
+	my $type_msg = $site_type ne '' ? " for site_type '$site_type'" : " (global)";
+	print "No default container was configured for application '$app_id'$type_msg\n";
+    }
+    else
+    {
+	my $type_msg = $site_type ne '' ? " for site_type '$site_type'" : " (global)";
+	print "Removed default container for application '$app_id'$type_msg\n";
+    }
+    exit 0;
+}
+
+die($usage->text) if @ARGV != 2;
+
+my $app_id = shift;
+my $container_id = shift;
+
+#
+# Validate site_type if specified (must exist in SiteDefaultContainer)
+#
+if ($site_type ne '')
+{
+    my $valid_site_types = $db->dbh->selectcol_arrayref(
+	qq(SELECT DISTINCT site_type FROM SiteDefaultContainer WHERE site_type IS NOT NULL)
+    );
+    my %valid = map { $_ => 1 } @$valid_site_types;
+
+    if (!$valid{$site_type})
+    {
+	my $valid_list = join(", ", sort @$valid_site_types);
+	die "Invalid site_type '$site_type'.\n" .
+	    "Valid site_type values are: $valid_list\n";
+    }
+}
+
+#
+# Verify the container ID exists in the Container table
+#
+my $container = $db->dbh->selectrow_arrayref(
+    qq(SELECT id, filename FROM Container WHERE id = ?),
+    undef, $container_id
+);
+
+if (!$container)
+{
+    die "Container ID '$container_id' does not exist in the Container table.\n" .
+	"Use p3x-add-container to add it first.\n";
+}
+
+#
+# Check if application already has a default container for this site_type
+#
+my $existing = $db->dbh->selectrow_arrayref(
+    qq(SELECT application_id, site_type, default_container_id
+       FROM ApplicationDefaultContainer
+       WHERE application_id = ? AND site_type = ?),
+    undef, $app_id, $site_type
+);
+
+my $type_msg = $site_type ne '' ? " for site_type '$site_type'" : " (global)";
+
+if ($existing)
+{
+    #
+    # Update existing record
+    #
+    my $old_container = $existing->[2];
+
+    if ($old_container eq $container_id)
+    {
+	print "Application '$app_id'$type_msg already has container '$container_id' as default.\n";
+	exit 0;
+    }
+
+    my $res;
+    $res = $db->dbh->do(
+	qq(UPDATE ApplicationDefaultContainer SET default_container_id = ?
+	   WHERE application_id = ? AND site_type = ?),
+	undef, $container_id, $app_id, $site_type
+    );
+
+    if ($res != 1)
+    {
+	die "Failed to update default container for application\n";
+    }
+
+    print "Updated application '$app_id'$type_msg default container from '$old_container' to '$container_id'\n";
+}
+else
+{
+    #
+    # Insert new record
+    #
+    my $res = $db->dbh->do(
+	qq(INSERT INTO ApplicationDefaultContainer (application_id, site_type, default_container_id)
+	   VALUES (?, ?, ?)),
+	undef, $app_id, $site_type, $container_id
+    );
+
+    if ($res != 1)
+    {
+	die "Failed to insert default container for application\n";
+    }
+
+    print "Set application '$app_id'$type_msg default container to '$container_id'\n";
+}

--- a/service-scripts/p3x-show-container-config.pl
+++ b/service-scripts/p3x-show-container-config.pl
@@ -1,0 +1,204 @@
+=head1 NAME
+
+    p3x-show-container-config - show container configuration status
+
+=head1 SYNOPSIS
+
+    p3x-show-container-config [OPTION]
+
+=head1 DESCRIPTION
+
+Displays the status of all container-related tables in the scheduler database:
+
+=over 4
+
+=item * Container - all registered container images
+
+=item * ApplicationDefaultContainer - per-application container overrides
+
+=item * SiteDefaultContainer - per-site (base_url) container overrides
+
+=item * Cluster - cluster default containers
+
+=back
+
+=cut
+
+use strict;
+use Data::Dumper;
+use Bio::KBase::AppService::SchedulerDB;
+
+use Getopt::Long::Descriptive;
+
+my($opt, $usage) = describe_options("%c %o",
+				    ["containers|c" => "Show only Container table"],
+				    ["apps|a" => "Show only ApplicationDefaultContainer table"],
+				    ["sites|s" => "Show only SiteDefaultContainer table"],
+				    ["clusters|C" => "Show only Cluster table"],
+				    ["help|h" => "Show this help message."],
+				    );
+print($usage->text), exit 0 if $opt->help;
+
+my $db = Bio::KBase::AppService::SchedulerDB->new();
+
+#
+# If no specific table requested, show all
+#
+my $show_all = !($opt->containers || $opt->apps || $opt->sites || $opt->clusters);
+
+#
+# Container table
+#
+if ($show_all || $opt->containers)
+{
+    print "=" x 80, "\n";
+    print "CONTAINERS (Container table - last 5 by date)\n";
+    print "=" x 80, "\n\n";
+
+    my $res = $db->dbh->selectall_arrayref(
+	qq(SELECT id, filename, creation_date FROM Container
+	   ORDER BY creation_date DESC
+	   LIMIT 5),
+	{ Slice => {} }
+    );
+
+    if (@$res == 0)
+    {
+	print "  No containers registered.\n";
+    }
+    else
+    {
+	printf "  %-40s %-40s %s\n", "Container ID", "Filename", "Created";
+	printf "  %-40s %-40s %s\n", "-" x 40, "-" x 40, "-" x 20;
+	for my $row (@$res)
+	{
+	    printf "  %-40s %-40s %s\n",
+		$row->{id},
+		$row->{filename} // "(none)",
+		$row->{creation_date} // "";
+	}
+    }
+    print "\n";
+}
+
+#
+# ApplicationDefaultContainer table
+#
+if ($show_all || $opt->apps)
+{
+    print "=" x 80, "\n";
+    print "APPLICATION DEFAULT CONTAINERS (ApplicationDefaultContainer table)\n";
+    print "=" x 80, "\n\n";
+
+    my $res = $db->dbh->selectall_arrayref(
+	qq(SELECT adc.application_id, adc.site_type, adc.default_container_id, c.filename
+	   FROM ApplicationDefaultContainer adc
+	   LEFT JOIN Container c ON adc.default_container_id = c.id
+	   ORDER BY adc.application_id, adc.site_type),
+	{ Slice => {} }
+    );
+
+    if (@$res == 0)
+    {
+	print "  No application default containers configured.\n";
+    }
+    else
+    {
+	printf "  %-30s %-12s %-30s %s\n", "Application", "Site Type", "Container ID", "Filename";
+	printf "  %-30s %-12s %-30s %s\n", "-" x 30, "-" x 12, "-" x 30, "-" x 25;
+	for my $row (@$res)
+	{
+	    printf "  %-30s %-12s %-30s %s\n",
+		$row->{application_id},
+		$row->{site_type} eq '' ? "(global)" : $row->{site_type},
+		$row->{default_container_id} // "(none)",
+		$row->{filename} // "";
+	}
+    }
+    print "\n";
+}
+
+#
+# SiteDefaultContainer table
+#
+if ($show_all || $opt->sites)
+{
+    print "=" x 80, "\n";
+    print "SITE DEFAULT CONTAINERS (SiteDefaultContainer table)\n";
+    print "=" x 80, "\n\n";
+
+    my $res = $db->dbh->selectall_arrayref(
+	qq(SELECT sdc.base_url, sdc.default_container_id, c.filename, sdc.last_modified
+	   FROM SiteDefaultContainer sdc
+	   LEFT JOIN Container c ON sdc.default_container_id = c.id
+	   ORDER BY sdc.base_url),
+	{ Slice => {} }
+    );
+
+    if (@$res == 0)
+    {
+	print "  No site default containers configured.\n";
+    }
+    else
+    {
+	printf "  %-50s %-30s %s\n", "Base URL", "Container ID", "Last Modified";
+	printf "  %-50s %-30s %s\n", "-" x 50, "-" x 30, "-" x 20;
+	for my $row (@$res)
+	{
+	    printf "  %-50s %-30s %s\n",
+		$row->{base_url},
+		$row->{default_container_id} // "(none)",
+		$row->{last_modified} // "";
+	}
+    }
+    print "\n";
+}
+
+#
+# Cluster table (container-related fields only)
+#
+if ($show_all || $opt->clusters)
+{
+    print "=" x 80, "\n";
+    print "CLUSTER DEFAULT CONTAINERS (Cluster table)\n";
+    print "=" x 80, "\n\n";
+
+    my $res = $db->dbh->selectall_arrayref(
+	qq(SELECT cl.id, cl.name, cl.default_container_id, c.filename,
+	          cl.container_repo_url, cl.container_cache_dir,
+	          cl.default_data_container_id, dc.name as data_container_name
+	   FROM Cluster cl
+	   LEFT JOIN Container c ON cl.default_container_id = c.id
+	   LEFT JOIN DataContainer dc ON cl.default_data_container_id = dc.id
+	   ORDER BY cl.id),
+	{ Slice => {} }
+    );
+
+    if (@$res == 0)
+    {
+	print "  No clusters configured.\n";
+    }
+    else
+    {
+	for my $row (@$res)
+	{
+	    print "  Cluster: $row->{id}";
+	    print " ($row->{name})" if $row->{name};
+	    print "\n";
+
+	    printf "    %-30s %s\n", "Default Container:",
+		$row->{default_container_id} // "(none)";
+	    printf "    %-30s %s\n", "Container Filename:",
+		$row->{filename} // "(none)" if $row->{default_container_id};
+	    printf "    %-30s %s\n", "Container Repo URL:",
+		$row->{container_repo_url} // "(none)";
+	    printf "    %-30s %s\n", "Container Cache Dir:",
+		$row->{container_cache_dir} // "(none)";
+	    printf "    %-30s %s\n", "Default Data Container:",
+		$row->{default_data_container_id} // "(none)";
+	    printf "    %-30s %s\n", "Data Container Name:",
+		$row->{data_container_name} // "(none)" if $row->{default_data_container_id};
+	    print "\n";
+	}
+    }
+}

--- a/service-scripts/p3x-submit-job.pl
+++ b/service-scripts/p3x-submit-job.pl
@@ -191,30 +191,62 @@ sub run_preflight
 	# Check for app override of container
 	#
 	my $task_container = $db->determine_container_id_override($task_params, $start_params);
-	
+
+	#
+	# Look up site_type from SiteDefaultContainer using base_url
+	#
+	my $site_type;
+	my $site_default_container;
+	if (my $base_url = $start_params->{base_url})
+	{
+	    my $site_default = $db->schema->resultset("SiteDefaultContainer")->find($base_url);
+	    if ($site_default)
+	    {
+		$site_type = $site_default->site_type;
+		$site_default_container = $site_default->default_container_id;
+	    }
+	}
+
 	if (!$task_container)
 	{
 	    #
-	    # Check for container defined for this application type
+	    # Check for container defined for this application type + site_type
 	    #
+	    if ($site_type)
+	    {
+		my $app_site_default = $db->schema->resultset('ApplicationDefaultContainer')
+		    ->find({ application_id => $app_id, site_type => $site_type });
+		if ($app_site_default)
+		{
+		    $task_container = $app_site_default->default_container_id;
+		    print STDERR "Using app+site_type container $task_container for $app_id / $site_type\n";
+		}
+	    }
+	}
 
-	    my $app_default = $db->schema->resultset('ApplicationDefaultContainer')->find($app_id);
+	if (!$task_container)
+	{
+	    #
+	    # Check for global container default for this application (site_type='')
+	    #
+	    my $app_default = $db->schema->resultset('ApplicationDefaultContainer')
+		->find({ application_id => $app_id, site_type => '' });
 	    if ($app_default)
 	    {
 		$task_container = $app_default->default_container_id;
+		print STDERR "Using global app container $task_container for $app_id\n";
 	    }
 	}
+
 	if (!$task_container)
 	{
-	    # Check for container defined for base url
-	    if (my $base_url = $start_params->{base_url})
+	    #
+	    # Fall back to site default container
+	    #
+	    if ($site_default_container)
 	    {
-		my $site_default = $db->schema->resultset("SiteDefaultContainer")->find($base_url);
-		if ($site_default)
-		{
-		    $task_container = $site_default->default_container_id;
-		    print STDERR "found container $task_container for $base_url\n";
-		}
+		$task_container = $site_default_container;
+		print STDERR "Using site default container $task_container\n";
 	    }
 	}
 	


### PR DESCRIPTION
## Summary

- **Site-specific container selection**: Adds `site_type` column to `ApplicationDefaultContainer`, allowing different default containers per application per site (e.g., production vs development). Container resolution hierarchy: task override → app+site default → app global default → site default → cluster default.
- **`--storage` option for `p3x-reset-job`**: Allows overriding the `_preflight.storage` value when resetting a job. Accepts T/G/M/K suffixes (e.g., `--storage 50G`). Updates the storage value in the Task params JSON, which controls the node temp space check in the batch script.

## Test plan
- [x] Verify container selection picks app+site_type match when available
- [x] Verify fallback to app global default when no site_type match
- [x] `p3x-reset-job --storage 50G <jobid>` updates `_preflight.storage` in params
- [x] Storage suffix parsing: `50G` → 50000000000, `1.5T` → 1500000000000

🤖 Generated with [Claude Code](https://claude.com/claude-code)