### PR TITLE
Add enumerate_tasks_qstat API for remote queue inspection

### DIFF
--- a/AppService.spec
+++ b/AppService.spec
@@ -120,6 +120,62 @@ module AppService
     funcdef query_app_summary_filtered(SimpleTaskFilter simple_filter)
 	returns (mapping<app_id app, int count> status);
 
+    /*
+     * Queue-inspection ("qstat") support.
+     *
+     * QStatFilter carries the filters supported by the p3x-qstat access
+     * pattern plus cross-user controls. Visibility is enforced in the
+     * implementation: a non-administrator may see only their own jobs unless
+     * all_users is set, in which case the whole queue is returned but every
+     * row the caller does not own is masked (id, owner and app blanked and
+     * the "masked" flag set). Administrators (role-based token) see everything
+     * unmasked and may restrict to a single owner.
+     */
+    typedef structure {
+	string start_time;        /* submit_time >= */
+	string end_time;          /* submit_time <  */
+	string started_after;     /* start_time  >= */
+	app_id app;
+	string status;            /* state_code (comma-separated list allowed) */
+	string cluster;
+	list<string> compute_nodes;
+	string user_metadata;
+	int include_archived;
+	int include_inactive;     /* include inactive cluster executions */
+	int include_parameters;   /* return task parameters (own/admin rows only) */
+	string sort_field;        /* submit_time|start_time|finish_time|application_id|status|id|maxrss */
+	string sort_order;        /* asc|desc */
+	string owner;             /* admin only: restrict to one owner */
+	int all_users;            /* request whole queue (non-owned rows masked for non-admins) */
+    } QStatFilter;
+
+    typedef structure {
+	task_id id;               /* "" when masked */
+	string owner;             /* "" when masked */
+	app_id app;               /* "" when masked */
+	int masked;               /* 1 if this row is masked from the caller */
+	task_status status;       /* TaskState description */
+	string submit_time;
+	string start_time;
+	string finish_time;
+	string elapsed_time;
+	string output_path;
+	string output_file;
+	string user_metadata;
+	int req_cpu;
+	string req_memory;
+	int req_runtime;
+	string cluster_id;
+	string cluster_job_id;    /* cluster (e.g. Slurm) job id */
+	string cluster_job_status;
+	string nodelist;
+	float maxrss;
+	task_parameters parameters;
+    } QStatTask;
+
+    funcdef enumerate_tasks_qstat(int offset, int count, QStatFilter filter)
+	returns (list<QStatTask> tasks, int total_tasks);
+
     funcdef kill_task(task_id id) returns (int killed, string msg);
     funcdef kill_tasks(list<task_id> ids) returns (mapping<task_id, structure { int killed; string msg; }>);
     funcdef rerun_task(task_id id) returns (Task task);

--- a/lib/Bio/KBase/AppService/AppServiceImpl.pm
+++ b/lib/Bio/KBase/AppService/AppServiceImpl.pm
@@ -1495,6 +1495,221 @@ sub query_app_summary_filtered
 }
 
 
+=head2 enumerate_tasks_qstat
+
+  $tasks, $total_tasks = $obj->enumerate_tasks_qstat($offset, $count, $filter)
+
+=over 4
+
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$offset is an int
+$count is an int
+$filter is a QStatFilter
+$tasks is a reference to a list where each element is a QStatTask
+$total_tasks is an int
+QStatFilter is a reference to a hash where the following keys are defined:
+	start_time has a value which is a string
+	end_time has a value which is a string
+	started_after has a value which is a string
+	app has a value which is an app_id
+	status has a value which is a string
+	cluster has a value which is a string
+	compute_nodes has a value which is a reference to a list where each element is a string
+	user_metadata has a value which is a string
+	include_archived has a value which is an int
+	include_inactive has a value which is an int
+	include_parameters has a value which is an int
+	sort_field has a value which is a string
+	sort_order has a value which is a string
+	owner has a value which is a string
+	all_users has a value which is an int
+app_id is a string
+QStatTask is a reference to a hash where the following keys are defined:
+	id has a value which is a task_id
+	owner has a value which is a string
+	app has a value which is an app_id
+	masked has a value which is an int
+	status has a value which is a task_status
+	submit_time has a value which is a string
+	start_time has a value which is a string
+	finish_time has a value which is a string
+	elapsed_time has a value which is a string
+	output_path has a value which is a string
+	output_file has a value which is a string
+	user_metadata has a value which is a string
+	req_cpu has a value which is an int
+	req_memory has a value which is a string
+	req_runtime has a value which is an int
+	cluster_id has a value which is a string
+	cluster_job_id has a value which is a string
+	cluster_job_status has a value which is a string
+	nodelist has a value which is a string
+	maxrss has a value which is a float
+	parameters has a value which is a task_parameters
+task_id is a string
+task_status is a string
+task_parameters is a reference to a hash where the key is a string and the value is a string
+</pre>
+
+=end html
+
+=begin text
+
+$offset is an int
+$count is an int
+$filter is a QStatFilter
+$tasks is a reference to a list where each element is a QStatTask
+$total_tasks is an int
+QStatFilter is a reference to a hash where the following keys are defined:
+	start_time has a value which is a string
+	end_time has a value which is a string
+	started_after has a value which is a string
+	app has a value which is an app_id
+	status has a value which is a string
+	cluster has a value which is a string
+	compute_nodes has a value which is a reference to a list where each element is a string
+	user_metadata has a value which is a string
+	include_archived has a value which is an int
+	include_inactive has a value which is an int
+	include_parameters has a value which is an int
+	sort_field has a value which is a string
+	sort_order has a value which is a string
+	owner has a value which is a string
+	all_users has a value which is an int
+app_id is a string
+QStatTask is a reference to a hash where the following keys are defined:
+	id has a value which is a task_id
+	owner has a value which is a string
+	app has a value which is an app_id
+	masked has a value which is an int
+	status has a value which is a task_status
+	submit_time has a value which is a string
+	start_time has a value which is a string
+	finish_time has a value which is a string
+	elapsed_time has a value which is a string
+	output_path has a value which is a string
+	output_file has a value which is a string
+	user_metadata has a value which is a string
+	req_cpu has a value which is an int
+	req_memory has a value which is a string
+	req_runtime has a value which is an int
+	cluster_id has a value which is a string
+	cluster_job_id has a value which is a string
+	cluster_job_status has a value which is a string
+	nodelist has a value which is a string
+	maxrss has a value which is a float
+	parameters has a value which is a task_parameters
+task_id is a string
+task_status is a string
+task_parameters is a reference to a hash where the key is a string and the value is a string
+
+=end text
+
+
+
+=item Description
+
+
+=back
+
+=cut
+
+sub enumerate_tasks_qstat
+{
+    my $self = shift;
+    my($offset, $count, $filter) = @_;
+
+    my @_bad_arguments;
+    (!ref($offset)) or push(@_bad_arguments, "Invalid type for argument \"offset\" (value was \"$offset\")");
+    (!ref($count)) or push(@_bad_arguments, "Invalid type for argument \"count\" (value was \"$count\")");
+    (ref($filter) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument \"filter\" (value was \"$filter\")");
+    if (@_bad_arguments) {
+	my $msg = "Invalid arguments passed to enumerate_tasks_qstat:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	die $msg;
+    }
+
+    my $ctx = $Bio::KBase::AppService::Service::CallContext;
+    my($tasks, $total_tasks);
+    #BEGIN enumerate_tasks_qstat
+
+    #
+    # Visibility enforcement lives here (the trust boundary), never in the
+    # client. Determine whether the caller is an administrator via the
+    # role-based token check, then build a scope the DB layer must honor.
+    #
+    my $user_id = $ctx->user_id;
+    my $is_admin = 0;
+    eval {
+	$is_admin = P3AuthToken->new(token => $ctx->token, ignore_authrc => 1)->is_admin ? 1 : 0;
+    };
+
+    my $all_users = $filter->{all_users} ? 1 : 0;
+
+    my $scope;
+    my $mask_for;
+    if ($is_admin)
+    {
+	#
+	# Admins see everything unmasked and may restrict to a single owner.
+	#
+	$scope = { restrict_owner => $filter->{owner} };
+    }
+    elsif ($all_users)
+    {
+	#
+	# Non-admin whole-queue view: the DB returns all rows, but rows the
+	# caller does not own are masked below. A non-admin may not target a
+	# specific owner.
+	#
+	$scope = { restrict_owner => undef };
+	$mask_for = $user_id;
+    }
+    else
+    {
+	#
+	# Default: the caller may see only their own jobs. This is forced as a
+	# WHERE clause in the DB layer, so a crafted call cannot see foreign rows.
+	#
+	$scope = { restrict_owner => $user_id };
+    }
+
+    ($tasks, $total_tasks) = $self->{scheduler_db}->enumerate_tasks_qstat($scope, $offset, $count, $filter);
+
+    #
+    # Mask identifying fields on rows the caller does not own. State, timing,
+    # cluster, node and RAM remain visible; id, owner and application are
+    # redacted and parameters are dropped.
+    #
+    if (defined($mask_for))
+    {
+	for my $t (@$tasks)
+	{
+	    next if lc($t->{owner} // '') eq lc($mask_for);
+	    $t->{id} = '';
+	    $t->{owner} = '';
+	    $t->{app} = '';
+	    $t->{masked} = 1;
+	    delete $t->{parameters};
+	}
+    }
+
+    #END enumerate_tasks_qstat
+    my @_bad_returns;
+    (ref($tasks) eq 'ARRAY') or push(@_bad_returns, "Invalid type for return variable \"tasks\" (value was \"$tasks\")");
+    (!ref($total_tasks)) or push(@_bad_returns, "Invalid type for return variable \"total_tasks\" (value was \"$total_tasks\")");
+    if (@_bad_returns) {
+	my $msg = "Invalid returns passed to enumerate_tasks_qstat:\n" . join("", map { "\t$_\n" } @_bad_returns);
+	die $msg;
+    }
+    return($tasks, $total_tasks);
+}
+
+
 =head2 kill_task
 
   $killed, $msg = $obj->kill_task($id)
@@ -2220,6 +2435,140 @@ status has a value which is a string
 include_archived has a value which is an int
 sort_field has a value which is a string
 sort_order has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 QStatFilter
+
+=over 4
+
+
+=item Description
+
+request whole queue (non-owned rows masked for non-admins)
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+start_time has a value which is a string
+end_time has a value which is a string
+started_after has a value which is a string
+app has a value which is an app_id
+status has a value which is a string
+cluster has a value which is a string
+compute_nodes has a value which is a reference to a list where each element is a string
+user_metadata has a value which is a string
+include_archived has a value which is an int
+include_inactive has a value which is an int
+include_parameters has a value which is an int
+sort_field has a value which is a string
+sort_order has a value which is a string
+owner has a value which is a string
+all_users has a value which is an int
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+start_time has a value which is a string
+end_time has a value which is a string
+started_after has a value which is a string
+app has a value which is an app_id
+status has a value which is a string
+cluster has a value which is a string
+compute_nodes has a value which is a reference to a list where each element is a string
+user_metadata has a value which is a string
+include_archived has a value which is an int
+include_inactive has a value which is an int
+include_parameters has a value which is an int
+sort_field has a value which is a string
+sort_order has a value which is a string
+owner has a value which is a string
+all_users has a value which is an int
+
+
+=end text
+
+=back
+
+
+
+=head2 QStatTask
+
+=over 4
+
+
+=item Description
+
+cluster (e.g. Slurm) job id
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+id has a value which is a task_id
+owner has a value which is a string
+app has a value which is an app_id
+masked has a value which is an int
+status has a value which is a task_status
+submit_time has a value which is a string
+start_time has a value which is a string
+finish_time has a value which is a string
+elapsed_time has a value which is a string
+output_path has a value which is a string
+output_file has a value which is a string
+user_metadata has a value which is a string
+req_cpu has a value which is an int
+req_memory has a value which is a string
+req_runtime has a value which is an int
+cluster_id has a value which is a string
+cluster_job_id has a value which is a string
+cluster_job_status has a value which is a string
+nodelist has a value which is a string
+maxrss has a value which is a float
+parameters has a value which is a task_parameters
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+id has a value which is a task_id
+owner has a value which is a string
+app has a value which is an app_id
+masked has a value which is an int
+status has a value which is a task_status
+submit_time has a value which is a string
+start_time has a value which is a string
+finish_time has a value which is a string
+elapsed_time has a value which is a string
+output_path has a value which is a string
+output_file has a value which is a string
+user_metadata has a value which is a string
+req_cpu has a value which is an int
+req_memory has a value which is a string
+req_runtime has a value which is an int
+cluster_id has a value which is a string
+cluster_job_id has a value which is a string
+cluster_job_status has a value which is a string
+nodelist has a value which is a string
+maxrss has a value which is a float
+parameters has a value which is a task_parameters
 
 
 =end text

--- a/lib/Bio/KBase/AppService/SchedulerDB.pm
+++ b/lib/Bio/KBase/AppService/SchedulerDB.pm
@@ -1204,6 +1204,233 @@ sub enumerate_tasks_filtered
     return ($tasks, $total_tasks);
 }
 
+=item B<_build_qstat_conditions>
+
+    my($where, @params) = $self->_build_qstat_conditions($scope, $filter);
+
+Build the WHERE clause and bind parameters for the qstat access pattern.
+
+$scope controls owner visibility and is set by the service implementation (the
+trust boundary), never by the client:
+
+  restrict_owner => $user   Force "t.owner = $user" (per-user isolation). When
+                            undef, no owner restriction is applied (admin, or the
+                            masked whole-queue view).
+
+$filter is a QStatFilter hash. Table aliases: t=Task, te=TaskExecution,
+cj=ClusterJob, ts=TaskState.
+
+=cut
+
+sub _normalize_owner
+{
+    my($self, $u) = @_;
+    return $u unless defined $u && length $u;
+    $u .= '@patricbrc.org' if $u !~ /@/;
+    return $u;
+}
+
+sub _build_qstat_conditions
+{
+    my($self, $scope, $filter) = @_;
+
+    require DateTime::Format::MySQL;
+    require DateTime::Format::DateParse;
+
+    my @cond = ('1=1');
+    my @param;
+
+    #
+    # Owner isolation. Only applied when the caller's scope demands it.
+    #
+    if (defined(my $owner = $scope->{restrict_owner}) && length($scope->{restrict_owner} // ''))
+    {
+	push(@cond, "t.owner = ?");
+	push(@param, $self->_normalize_owner($owner));
+    }
+
+    my $parse_dt = sub {
+	my($v) = @_;
+	my $dt = eval { DateTime::Format::DateParse->parse_datetime($v) };
+	return $dt ? DateTime::Format::MySQL->format_datetime($dt) : undef;
+    };
+
+    if (my $t = $filter->{start_time})
+    {
+	if (my $d = $parse_dt->($t)) { push(@cond, "t.submit_time >= ?"); push(@param, $d); }
+    }
+    if (my $t = $filter->{end_time})
+    {
+	if (my $d = $parse_dt->($t)) { push(@cond, "t.submit_time < ?"); push(@param, $d); }
+    }
+    if (my $t = $filter->{started_after})
+    {
+	if (my $d = $parse_dt->($t)) { push(@cond, "t.start_time >= ?"); push(@param, $d); }
+    }
+
+    if (my $app = $filter->{app})
+    {
+	if ($app =~ /^[0-9a-zA-Z_]+$/)
+	{
+	    push(@cond, "t.application_id = ?");
+	    push(@param, $app);
+	}
+    }
+
+    if (defined(my $st = $filter->{status}) && length $filter->{status})
+    {
+	my @codes = grep { /^[-0-9a-zA-Z]+$/ } split(/,/, $st);
+	if (@codes)
+	{
+	    push(@cond, "t.state_code IN (" . join(",", ("?") x @codes) . ")");
+	    push(@param, @codes);
+	}
+    }
+
+    if (defined(my $cl = $filter->{cluster}) && length $filter->{cluster})
+    {
+	push(@cond, "cj.cluster_id = ?");
+	push(@param, $cl);
+    }
+
+    if (my $nodes = $filter->{compute_nodes})
+    {
+	if (ref($nodes) eq 'ARRAY' && @$nodes)
+	{
+	    push(@cond, "cj.nodelist IN (" . join(",", ("?") x @$nodes) . ")");
+	    push(@param, @$nodes);
+	}
+    }
+
+    if (defined(my $um = $filter->{user_metadata}) && length $filter->{user_metadata})
+    {
+	push(@cond, "t.user_metadata = ?");
+	push(@param, $um);
+    }
+
+    if (!$filter->{include_inactive})
+    {
+	push(@cond, "(te.active = 1 OR te.active IS NULL)");
+    }
+
+    my $cond = join(" AND ", map { "($_)" } @cond);
+    return ($cond, @param);
+}
+
+=item B<enumerate_tasks_qstat>
+
+    my($tasks, $total) = $self->enumerate_tasks_qstat($scope, $offset, $count, $filter);
+
+Return queue records in the p3x-qstat style: Task joined to its (active) cluster
+execution, with cluster-level fields. Owner visibility is governed by $scope
+(see _build_qstat_conditions); masking of foreign rows is done by the caller
+(the service implementation). Returns the list of task hashes and the total count
+of matching tasks (ignoring offset/count).
+
+=cut
+
+sub enumerate_tasks_qstat
+{
+    my($self, $scope, $offset, $count, $filter) = @_;
+
+    $offset = 0 unless defined $offset && $offset =~ /^\d+$/;
+    $count  = 0 unless defined $count  && $count  =~ /^\d+$/;
+
+    my ($cond, @param) = $self->_build_qstat_conditions($scope, $filter);
+
+    my %valid_sort_fields = (
+	submit_time    => 't.submit_time',
+	start_time     => 't.start_time',
+	finish_time    => 't.finish_time',
+	application_id => 't.application_id',
+	status         => 'ts.service_status',
+	id             => 't.id',
+	maxrss         => 'cj.maxrss',
+    );
+    my $order_col = $valid_sort_fields{$filter->{sort_field} // ''} // 't.submit_time';
+    my $sort_order = lc($filter->{sort_order} // 'desc') eq 'asc' ? 'ASC' : 'DESC';
+    my $order_clause = "ORDER BY $order_col $sort_order";
+
+    my $joins = qq(FROM Task t
+		   LEFT OUTER JOIN TaskExecution te ON te.task_id = t.id
+		   LEFT OUTER JOIN ClusterJob cj ON cj.id = te.cluster_job_id
+		   JOIN TaskState ts ON t.state_code = ts.code
+		   WHERE $cond);
+
+    my $dbh = $self->dbh;
+
+    #
+    # Total count (independent of offset/count). DISTINCT guards against a task
+    # with more than one matching execution row.
+    #
+    my $count_row = $dbh->selectcol_arrayref(qq(SELECT COUNT(DISTINCT t.id) $joins), undef, @param);
+    my $total = int($count_row->[0] // 0);
+
+    my $tasks = [];
+    if ($count > 0)
+    {
+	my $want_params = $filter->{include_parameters} ? 1 : 0;
+
+	my $fields = qq(t.id, t.owner, t.application_id,
+			ts.description as state_desc,
+			IF(t.submit_time = default(t.submit_time), '', DATE_FORMAT(CONVERT_TZ(t.submit_time, \@\@session.time_zone, '+00:00'), '%Y-%m-%dT%TZ')) as submit_time,
+			IF(t.start_time = default(t.start_time), '', DATE_FORMAT(CONVERT_TZ(t.start_time, \@\@session.time_zone, '+00:00'), '%Y-%m-%dT%TZ')) as start_time,
+			IF(t.finish_time = default(t.finish_time), '', DATE_FORMAT(CONVERT_TZ(t.finish_time, \@\@session.time_zone, '+00:00'), '%Y-%m-%dT%TZ')) as finish_time,
+			IF(t.finish_time != default(t.finish_time) AND t.start_time != default(t.start_time), timediff(t.finish_time, t.start_time), '') as elapsed_time,
+			t.output_path, t.output_file, t.user_metadata,
+			t.req_cpu, t.req_memory, t.req_runtime,
+			cj.cluster_id, cj.job_id as cluster_job_id, cj.job_status as cluster_job_status,
+			cj.nodelist, cj.maxrss);
+	$fields .= ", t.params" if $want_params;
+
+	my $qry = qq(SELECT $fields $joins $order_clause LIMIT ? OFFSET ?);
+	my $sth = $dbh->prepare($qry);
+	$sth->execute(@param, $count, $offset);
+
+	while (my $r = $sth->fetchrow_hashref())
+	{
+	    push(@$tasks, $self->format_qstat_task($r, $want_params));
+	}
+    }
+
+    return ($tasks, $total);
+}
+
+sub format_qstat_task
+{
+    my($self, $r, $want_params) = @_;
+
+    my $params = {};
+    if ($want_params && defined $r->{params})
+    {
+	$params = eval { decode_json($r->{params}) } // {};
+    }
+
+    return {
+	id                 => "" . ($r->{id} // ''),
+	owner              => $r->{owner} // '',
+	app                => $r->{application_id} // '',
+	masked             => 0,
+	status             => $r->{state_desc} // '',
+	submit_time        => $r->{submit_time} // '',
+	start_time         => $r->{start_time} // '',
+	finish_time        => $r->{finish_time} // '',
+	elapsed_time       => "" . ($r->{elapsed_time} // ''),
+	output_path        => $r->{output_path} // '',
+	output_file        => $r->{output_file} // '',
+	user_metadata      => $r->{user_metadata} // '',
+	req_cpu            => int($r->{req_cpu} // 0),
+	req_memory         => $r->{req_memory} // '',
+	req_runtime        => int($r->{req_runtime} // 0),
+	cluster_id         => $r->{cluster_id} // '',
+	cluster_job_id     => "" . ($r->{cluster_job_id} // ''),
+	cluster_job_status => $r->{cluster_job_status} // '',
+	nodelist           => $r->{nodelist} // '',
+	maxrss             => ($r->{maxrss} // 0) + 0,
+	parameters         => $params,
+    };
+}
+
 sub format_task_for_service
 {
     my($self, $task) = @_;

--- a/lib/javascript/AppService/Client.js
+++ b/lib/javascript/AppService/Client.js
@@ -144,6 +144,16 @@ function AppService(url, auth, auth_cb) {
         return json_call_ajax("AppService.query_app_summary_filtered", [simple_filter], 1, _callback, _error_callback);
     };
 
+    this.enumerate_tasks_qstat = function (offset, count, filter, _callback, _errorCallback) {
+    return json_call_ajax("AppService.enumerate_tasks_qstat",
+        [offset, count, filter], 2, _callback, _errorCallback);
+};
+
+    this.enumerate_tasks_qstat_async = function (offset, count, filter, _callback, _error_callback) {
+        deprecationWarning();
+        return json_call_ajax("AppService.enumerate_tasks_qstat", [offset, count, filter], 2, _callback, _error_callback);
+    };
+
     this.kill_task = function (id, _callback, _errorCallback) {
     return json_call_ajax("AppService.kill_task",
         [id], 2, _callback, _errorCallback);


### PR DESCRIPTION
## Summary

Exposes the `p3x-qstat` access pattern through the app service JSONRPC API so the
scheduler queue can be inspected remotely, with **visibility enforced on the
server**. Adds one method, `enumerate_tasks_qstat`, plus the request/response
types.

A companion client (`p3-qstat`, in `p3_cli`) is the intended consumer; unlike
`p3x-qstat.pl` it talks to this API instead of connecting directly to the
scheduler MySQL DB, so it works off-cluster.

## Access control (the point of the change)

- **Non-administrators see only their own jobs.** The owner restriction is forced
  as a SQL `WHERE` clause in the DB layer — a crafted RPC call cannot retrieve
  other users' rows.
- **`all_users`** lets a non-admin view the whole queue for operational context,
  but every row they don't own is **masked**: job id, owner, and application are
  blanked (`masked=1`) and parameters are dropped. Their own rows stay unmasked.
- **Administrators** (role-based `P3AuthToken::is_admin`) see everything unmasked
  and may restrict to a single owner. Masking is applied in the Impl (the trust
  boundary), not the client.

## Changes

- `AppService.spec`: `QStatFilter` / `QStatTask` typedefs and the
  `enumerate_tasks_qstat` funcdef. Clients regenerated via `compile-typespec`
  (JS client committed; Perl/Python clients are generated at build time).
- `AppServiceImpl.pm`: admin resolution, scope construction, and foreign-row
  masking.
- `SchedulerDB.pm`: `enumerate_tasks_qstat` + `_build_qstat_conditions` — the
  `Task`/`TaskExecution`/`ClusterJob` join, qstat's filters (app, status,
  time windows, cluster, node, user-metadata, active/inactive), scope-aware
  owner restriction, and a bound-parameter `COUNT` for totals. Timestamps are
  returned as UTC ISO-8601 (clients localize).

## Verification

- `perl -c` clean on Impl / SchedulerDB / generated Service.pm & Client.pm;
  `make compile-typespec` and full `make` succeed.
- Offline checks of the WHERE-clause builder: owner clause forced for non-admins,
  absent for the (Impl-masked) all-users path, all filter values bound;
  masking self-test confirms foreign rows fully redacted and own rows intact.
- Live isolation/masking/parity vs `p3x-qstat` should be run after the service is
  redeployed (the new method isn't live until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)